### PR TITLE
Update customize.sh

### DIFF
--- a/module/customize.sh
+++ b/module/customize.sh
@@ -1,5 +1,5 @@
-# Error on < Android 8
-if [ "$API" -lt 26 ]; then
+# Error on < Android 9
+if [ "$API" -lt 28 ]; then
     abort "! You can't use this module on Android < 8.0"
 fi
 
@@ -11,6 +11,7 @@ fi
 if [ -d /data/adb/modules/MagiskHidePropsConf ]; then
     ui_print "! MagiskHidePropsConfig (MHPC) module may cause issues with PIF"
 fi
+rm -f /data/adb/pif.json
 
 # Copy any custom.pif.json to updated module
 if [ -f /data/adb/modules/playintegrityfix/custom.pif.json ]; then
@@ -21,3 +22,5 @@ fi
 # Clean up any leftover files from previous deprecated methods
 rm -f /data/data/com.google.android.gms/cache/pif.prop /data/data/com.google.android.gms/pif.prop
 rm -f /data/data/com.google.android.gms/cache/pif.json /data/data/com.google.android.gms/pif.json
+# Remove magisk 32bit zy support
+rm -f /debug_ramdisk/magisk32


### PR DESCRIPTION
Now almost no device with Android 9 and above uses 32bit support, creating unnecessary injection. I tried to add some code to remove this.