### PR TITLE
autopif.sh: Do not execute killgms.sh if not in default directory

### DIFF
--- a/module/autopif.sh
+++ b/module/autopif.sh
@@ -110,7 +110,9 @@ if [ "$DIR" = /data/adb/modules/playintegrityfix/autopif ]; then
   cp -fv $NEWNAME ..;
 fi;
 
-if [ -f /data/adb/modules/playintegrityfix/killgms.sh ]; then
-  item "Killing any running GMS DroidGuard process ...";
-  sh /data/adb/modules/playintegrityfix/killgms.sh 2>&1;
+if [ "$DIR" = /data/adb/modules/playintegrityfix/autopif ]; then
+  if [ -f /data/adb/modules/playintegrityfix/killgms.sh ]; then
+    item "Killing any running GMS DroidGuard process ...";
+    sh /data/adb/modules/playintegrityfix/killgms.sh 2>&1;
+  fi;
 fi;


### PR DESCRIPTION
As discussed,
https://xdaforums.com/t/tools-zips-scripts-osm0sis-odds-and-ends-multiple-devices-platforms.2239421/post-89650827