### PR TITLE
Fix SELinux prop spoofing

### DIFF
--- a/module/service.sh
+++ b/module/service.sh
@@ -10,10 +10,7 @@ resetprop_if_match vendor.boot.mode recovery unknown
 
 # SELinux
 resetprop_if_diff ro.boot.selinux enforcing
-# use delete since it can be 0 or 1 for enforcing depending on OEM
-if [ -n "$(resetprop ro.build.selinux)" ]; then
-    resetprop --delete ro.build.selinux
-fi
+resetprop_if_diff ro.build.selinux 1
 # use toybox to protect stat access time reading
 if [ "$(toybox cat /sys/fs/selinux/enforce)" = "0" ]; then
     chmod 640 /sys/fs/selinux/enforce


### PR DESCRIPTION
Using `resetprop --delete` will trigger ro property manipulation detection.