### PR TITLE
Fix root check issue in Termux by updating the detection method

### DIFF
--- a/module/autopif.sh
+++ b/module/autopif.sh
@@ -1,8 +1,16 @@
 #!/system/bin/sh
 
-if [ "$USER" != "root" -o "$(whoami 2>/dev/null)" != "root" ]; then
-  echo "autopif: need root permissions";
-  exit 1;
+if [ -n "$TERMUX_VERSION" ] || echo "$PREFIX" | grep -q "com.termux"; then
+  if [ "$(whoami 2>/dev/null)" != "root" ]; then
+    echo "autopif: need root permissions";
+    echo "autopif: please run tsu command (pkg install tsu)";
+    exit 1;
+  fi;
+else
+  if [ "$USER" != "root" ] || [ "$(whoami 2>/dev/null)" != "root" ]; then
+    echo "autopif: need root permissions";
+    exit 1;
+  fi;
 fi;
 
 case "$1" in

--- a/module/killgms.sh
+++ b/module/killgms.sh
@@ -4,9 +4,17 @@
 # Kill the Google Play services DroidGuard process
 # (com.google.android.gms.unstable)
 
-if [ "$USER" != "root" -o "$(whoami 2>/dev/null)" != "root" ]; then
-  echo "killgms: need root permissions";
-  exit 1;
+if [ -n "$TERMUX_VERSION" ] || echo "$PREFIX" | grep -q "com.termux"; then
+  if [ "$(whoami 2>/dev/null)" != "root" ]; then
+    echo "killgms: need root permissions";
+    echo "killgms: please run tsu command (pkg install tsu)";
+    exit 1;
+  fi;
+else
+  if [ "$USER" != "root" ] || [ "$(whoami 2>/dev/null)" != "root" ]; then
+    echo "killgms: need root permissions";
+    exit 1;
+  fi;
 fi;
 
 killall -v com.google.android.gms.unstable;


### PR DESCRIPTION
This PR addresses an issue with detecting root access in Termux environments. The original check:  
```bash
[ "$USER" != "root" -o "$(whoami 2>/dev/null)" != "root" ];
```  
was unreliable due to the `$USER` variable not being set in some cases within Termux. This caused the script to fail in correctly identifying whether it was being run as root.

To resolve this, I added an additional check specific to Termux environments:
```bash
[ -n "$TERMUX_VERSION" ] || echo "$PREFIX" | grep -q "com.termux";
```

This condition ensures that the script recognizes when it is running in Termux, allowing for more consistent detection of root status using an alternate method.