### PR TITLE
Add newer hOS prebuilds to default/example app replace list

### DIFF
--- a/module/example.app_replace.list
+++ b/module/example.app_replace.list
@@ -11,7 +11,9 @@
 /system/app/EliteDevelopmentModule
 /system/app/XInjectModule
 
-# hentaiOS
+# helluvaOS / hentaiOS
+/system_ext/app/helluvaProductDevice*
+/system_ext/app/helluvaProductSecretStub
 /system_ext/app/hentaiLewdbSVTDummy
 
 # Evolution X


### PR DESCRIPTION
In the lastest update "hentaiLewdbSVTDummy" was removed and those 2 were added.

Probably good to keep the old one for compatibility with older versions.