### PR TITLE
Fix retaining disabled ROM apps in some cases again

### DIFF
--- a/module/customize.sh
+++ b/module/customize.sh
@@ -13,7 +13,7 @@ fi
 # Copy any disabled app files to updated module
 if [ -d /data/adb/modules/playintegrityfix/system ]; then
     ui_print "- Restoring disabled ROM apps configuration"
-    cp -arf /data/adb/modules/playintegrityfix/system $MODPATH
+    cp -afL /data/adb/modules/playintegrityfix/system $MODPATH
 fi
 
 # Copy any supported custom files to updated module


### PR DESCRIPTION
At least on my setup on first install it was disabling correctly, on reflash/update the module stopped disabling and if I reflashed it was disabled again.

I'm disabling an app inside system_ext

On KernelSU and I am guessing also APatch on first install before reboot the folder for disabling is created inside "$MODPATH/system":
```
ls -l /data/adb/modules_update/playintegrityfix/system
drwxr-xr-x    3 root     root          4096 Oct 30 23:01 system_ext
```

After rebooting, the folder gets moved to the root of the module and a system link is generated:
```
ls -l /data/adb/modules/playintegrityfix/system
lrwxrwxrwx 1 root root 13 2024-10-30 23:01 system_ext -> ../system_ext

ls -l /data/adb/modules/playintegrityfix/system_ext
drwxr-xr-x 4 root root 4096 2024-10-30 23:01 app
```

So if you don't copy the referenced folder instead of the syslink after the reflash and rebooting, the syslink will be pointing into a missing folder.

I tested this on KernelSU and Magisk and on my end everything holds correctly.

I'm also removing the -r because its implicit in -a