### PR TITLE
module/action: don't sleep on MMRL action

### DIFF
--- a/module/action.sh
+++ b/module/action.sh
@@ -8,8 +8,10 @@ sh $MODPATH/autopif2.sh || exit 1
 
 echo -e "\nDone!"
 
-# warn since KernelSU's implementation automatically closes if successful
-if [ "$KSU" = "true" ]; then
+# dont sleep on Magisk and MMRL
+# those environments stops exec
+# and lets the user read
+if [ -z "$MAGISKTMP" ] && [ -z "$MMRL" ]; then
     echo -e "\nClosing dialog in 20 seconds ..."
     sleep 20
 fi


### PR DESCRIPTION
This is an upcoming feature on MMRL.
It also exits "paused"
juts like magisk, so we don't need to sleep here

https://github.com/user-attachments/assets/f8a3ea4a-3bae-46bf-b125-2106846544ee


printenv dump
[printenv.txt](https://github.com/user-attachments/files/18140126/printenv.txt)
