### PR TITLE
Add advanced setting spoofVendingFingerprint

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,10 +3,10 @@ name: Android CI
 on:
   workflow_dispatch:
   push:
-    branches: spoofVendingFingerprint
+    branches: main
     paths-ignore: '**.md'
   pull_request:
-    branches: spoofVendingFingerprint
+    branches: main
     paths-ignore: '**.md'
 
 jobs:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,10 +3,10 @@ name: Android CI
 on:
   workflow_dispatch:
   push:
-    branches: main
+    branches: spoofVendingFingerprint
     paths-ignore: '**.md'
   pull_request:
-    branches: main
+    branches: spoofVendingFingerprint
     paths-ignore: '**.md'
 
 jobs:

--- a/app/src/main/cpp/main.cpp
+++ b/app/src/main/cpp/main.cpp
@@ -324,7 +324,6 @@ private:
             LOGD("JNI %s: Calling EntryPoint.init", niceName);
             auto entryInit = env->GetStaticMethodID(entryClass, "init", "(IIII)V");
             env->CallStaticVoidMethod(entryClass, entryInit, verboseLogs, spoofBuild, spoofProvider, spoofSignature);
-            env->DeleteLocalRef(javaStr);
         }
         env->DeleteLocalRef(clClass);
         env->DeleteLocalRef(dexClClass);
@@ -333,6 +332,7 @@ private:
         env->DeleteLocalRef(buffer);
         env->DeleteLocalRef(entryClassName);
         env->DeleteLocalRef(entryClassObj);
+        env->DeleteLocalRef(javaStr);
     }
 };
 

--- a/app/src/main/cpp/main.cpp
+++ b/app/src/main/cpp/main.cpp
@@ -20,6 +20,7 @@ static int spoofBuild = 1;
 static int spoofProps = 1;
 static int spoofProvider = 1;
 static int spoofSignature = 0;
+static int spoofVendingFingperint = 0;
 static int spoofVendingSdk = 0;
 
 static std::map<std::string, std::string> jsonProps;
@@ -166,10 +167,10 @@ public:
         readJson();
 
         if (pkgName == VENDING_PACKAGE) spoofProps = spoofBuild = spoofProvider = spoofSignature = 0;
-        else spoofVendingSdk = 0;
+        else spoofVendingFingerprint = spoofVendingSdk = 0;
 
         if (spoofProps > 0) doHook();
-        if (spoofBuild + spoofProvider + spoofSignature + spoofVendingSdk > 0) inject();
+        if (spoofBuild + spoofProvider + spoofSignature + spoofVendingFingerprint + spoofVendingSdk > 0) inject();
 
         dexVector.clear();
         json.clear();
@@ -209,6 +210,16 @@ private:
                 LOGD("Error parsing spoofVendingSdk!");
             }
             json.erase("spoofVendingSdk");
+        }
+        // Only parse spoofVendingFingerprint if not forcing legacy verdict
+        if (spoofVendingSdk < 1 && json.contains("spoofVendingFingerprint")) {
+            if (!json["spoofVendingFingerprint"].is_null() && json["spoofVendingFingerprint"].is_string() && json["spoofVendingFingerprint"] != "") {
+                spoofVendingFingerprint = stoi(json["spoofVendingFingerprint"].get<std::string>());
+                if (verboseLogs > 0) LOGD("Spoofing Fingerprint in Play Store %s!", (spoofVendingFingerprint > 0) ? "enabled" : "disabled");
+            } else {
+                LOGD("Error parsing spoofVendingFingerprint!");
+            }
+            json.erase("spoofVendingFingerprint");
         }
         if (pkgName == VENDING_PACKAGE) {
             json.clear();

--- a/app/src/main/cpp/main.cpp
+++ b/app/src/main/cpp/main.cpp
@@ -324,6 +324,7 @@ private:
             LOGD("JNI %s: Calling EntryPoint.init", niceName);
             auto entryInit = env->GetStaticMethodID(entryClass, "init", "(IIII)V");
             env->CallStaticVoidMethod(entryClass, entryInit, verboseLogs, spoofBuild, spoofProvider, spoofSignature);
+            env->DeleteLocalRef(javaStr);
         }
         env->DeleteLocalRef(clClass);
         env->DeleteLocalRef(dexClClass);
@@ -332,7 +333,6 @@ private:
         env->DeleteLocalRef(buffer);
         env->DeleteLocalRef(entryClassName);
         env->DeleteLocalRef(entryClassObj);
-        env->DeleteLocalRef(javaStr);
     }
 };
 

--- a/app/src/main/cpp/main.cpp
+++ b/app/src/main/cpp/main.cpp
@@ -20,7 +20,7 @@ static int spoofBuild = 1;
 static int spoofProps = 1;
 static int spoofProvider = 1;
 static int spoofSignature = 0;
-static int spoofVendingFingperint = 0;
+static int spoofVendingFingerprint = 0;
 static int spoofVendingSdk = 0;
 
 static std::map<std::string, std::string> jsonProps;

--- a/app/src/main/cpp/main.cpp
+++ b/app/src/main/cpp/main.cpp
@@ -212,10 +212,9 @@ private:
             }
             json.erase("spoofVendingSdk");
         }
-        // Only parse spoofVendingFingerprint if not forcing legacy verdict and FINGERPRINT field exists
-        if (spoofVendingSdk < 1 && json.contains("spoofVendingFingerprint") && json.contains("FINGERPRINT")) {
+        if (json.contains("spoofVendingFingerprint")) {
             if (!json["spoofVendingFingerprint"].is_null() && json["spoofVendingFingerprint"].is_string() && json["spoofVendingFingerprint"] != "" &&
-                !json["FINGERPRINT"].is_null() && json["FINGERPRINT"].is_string() && json["FINGERPRINT"] != "") {
+                json.contains("FINGERPRINT") && !json["FINGERPRINT"].is_null() && json["FINGERPRINT"].is_string() && json["FINGERPRINT"] != "") {
                 spoofVendingFingerprint = stoi(json["spoofVendingFingerprint"].get<std::string>());
                 spoofFingerprintValue = json["spoofVendingFingerprint"].get<std::string>();
                 if (verboseLogs > 0) LOGD("Spoofing Fingerprint in Play Store %s!", (spoofVendingFingerprint > 0) ? "enabled" : "disabled");

--- a/app/src/main/cpp/main.cpp
+++ b/app/src/main/cpp/main.cpp
@@ -314,7 +314,7 @@ private:
         if (pkgName == VENDING_PACKAGE) {
             LOGD("JNI %s: Calling EntryPointVending.init", niceName);
             auto entryInit = env->GetStaticMethodID(entryClass, "init", "(II)V");
-            env->CallStaticVoidMethod(entryClass, entryInit, verboseLogs, spoofVendingFingerprint, spoofFingerprintValue, spoofVendingSdk);
+            env->CallStaticVoidMethod(entryClass, entryInit, verboseLogs, spoofVendingFingerprint, spoofVendingSdk, spoofFingerprintValue);
         } else {
             LOGD("JNI %s: Sending JSON", niceName);
             auto receiveJson = env->GetStaticMethodID(entryClass, "receiveJson", "(Ljava/lang/String;)V");

--- a/app/src/main/cpp/main.cpp
+++ b/app/src/main/cpp/main.cpp
@@ -186,7 +186,7 @@ private:
     std::vector<char> dexVector;
     nlohmann::json json;
     std::string pkgName;
-    std::string spoofFingerprintValue;
+    std::string spoofFingerprintValue = ""
 
     void readJson() {
         LOGD("JSON contains %d keys!", static_cast<int>(json.size()));
@@ -215,7 +215,7 @@ private:
         // Only parse spoofVendingFingerprint if not forcing legacy verdict and FINGERPRINT field exists
         if (spoofVendingSdk < 1 && json.contains("spoofVendingFingerprint") && json.contains("FINGERPRINT")) {
             if (!json["spoofVendingFingerprint"].is_null() && json["spoofVendingFingerprint"].is_string() && json["spoofVendingFingerprint"] != "" &&
-                !json["FINGERPRINT"].is_null() && json["FINGPERINT"].is_string() && json["FINGERPRINT"] != "") {
+                !json["FINGERPRINT"].is_null() && json["FINGERPRINT"].is_string() && json["FINGERPRINT"] != "") {
                 spoofVendingFingerprint = stoi(json["spoofVendingFingerprint"].get<std::string>());
                 spoofFingerprintValue = json["spoofVendingFingerprint"].get<std::string>();
                 if (verboseLogs > 0) LOGD("Spoofing Fingerprint in Play Store %s!", (spoofVendingFingerprint > 0) ? "enabled" : "disabled");

--- a/app/src/main/cpp/main.cpp
+++ b/app/src/main/cpp/main.cpp
@@ -313,7 +313,7 @@ private:
 
         if (pkgName == VENDING_PACKAGE) {
             LOGD("JNI %s: Calling EntryPointVending.init", niceName);
-            auto entryInit = env->GetStaticMethodID(entryClass, "init", "(II)V");
+            auto entryInit = env->GetStaticMethodID(entryClass, "init", "(IIILjava/lang/String;)V");
             env->CallStaticVoidMethod(entryClass, entryInit, verboseLogs, spoofVendingFingerprint, spoofVendingSdk, spoofFingerprintValue.c_str());
         } else {
             LOGD("JNI %s: Sending JSON", niceName);

--- a/app/src/main/cpp/main.cpp
+++ b/app/src/main/cpp/main.cpp
@@ -313,7 +313,8 @@ private:
         if (pkgName == VENDING_PACKAGE) {
             LOGD("JNI %s: Calling EntryPointVending.init", niceName);
             auto entryInit = env->GetStaticMethodID(entryClass, "init", "(IIILjava/lang/String;)V");
-            env->CallStaticVoidMethod(entryClass, entryInit, verboseLogs, spoofVendingFingerprint, spoofVendingSdk, spoofFingerprintValue.c_str());
+            auto javaStr = env->NewStringUTF(spoofFingerprintValue.c_str());
+            env->CallStaticVoidMethod(entryClass, entryInit, verboseLogs, spoofVendingFingerprint, spoofVendingSdk, javaStr);
         } else {
             LOGD("JNI %s: Sending JSON", niceName);
             auto receiveJson = env->GetStaticMethodID(entryClass, "receiveJson", "(Ljava/lang/String;)V");

--- a/app/src/main/cpp/main.cpp
+++ b/app/src/main/cpp/main.cpp
@@ -186,7 +186,7 @@ private:
     std::vector<char> dexVector;
     nlohmann::json json;
     std::string pkgName;
-    std::string spoofFingerprintValue = ""
+    std::string spoofFingerprintValue = "";
 
     void readJson() {
         LOGD("JSON contains %d keys!", static_cast<int>(json.size()));

--- a/app/src/main/cpp/main.cpp
+++ b/app/src/main/cpp/main.cpp
@@ -216,7 +216,7 @@ private:
             if (!json["spoofVendingFingerprint"].is_null() && json["spoofVendingFingerprint"].is_string() && json["spoofVendingFingerprint"] != "" &&
                 json.contains("FINGERPRINT") && !json["FINGERPRINT"].is_null() && json["FINGERPRINT"].is_string() && json["FINGERPRINT"] != "") {
                 spoofVendingFingerprint = stoi(json["spoofVendingFingerprint"].get<std::string>());
-                spoofFingerprintValue = json["spoofVendingFingerprint"].get<std::string>();
+                spoofFingerprintValue = json["FINGERPRINT"].get<std::string>();
                 if (verboseLogs > 0) LOGD("Spoofing Fingerprint in Play Store %s!", (spoofVendingFingerprint > 0) ? "enabled" : "disabled");
             } else {
                 LOGD("Error parsing spoofVendingFingerprint or FINGERPRINT field!");

--- a/app/src/main/cpp/main.cpp
+++ b/app/src/main/cpp/main.cpp
@@ -314,7 +314,7 @@ private:
         if (pkgName == VENDING_PACKAGE) {
             LOGD("JNI %s: Calling EntryPointVending.init", niceName);
             auto entryInit = env->GetStaticMethodID(entryClass, "init", "(II)V");
-            env->CallStaticVoidMethod(entryClass, entryInit, verboseLogs, spoofVendingFingerprint, spoofVendingSdk, (const char *) spoofFingerprintValue);
+            env->CallStaticVoidMethod(entryClass, entryInit, verboseLogs, spoofVendingFingerprint, spoofVendingSdk, spoofFingerprintValue.c_str());
         } else {
             LOGD("JNI %s: Sending JSON", niceName);
             auto receiveJson = env->GetStaticMethodID(entryClass, "receiveJson", "(Ljava/lang/String;)V");

--- a/app/src/main/cpp/main.cpp
+++ b/app/src/main/cpp/main.cpp
@@ -186,7 +186,7 @@ private:
     std::vector<char> dexVector;
     nlohmann::json json;
     std::string pkgName;
-    std::string spoofFingerprintValue;
+    String spoofFingerprintValue;
 
     void readJson() {
         LOGD("JSON contains %d keys!", static_cast<int>(json.size()));

--- a/app/src/main/cpp/main.cpp
+++ b/app/src/main/cpp/main.cpp
@@ -186,7 +186,7 @@ private:
     std::vector<char> dexVector;
     nlohmann::json json;
     std::string pkgName;
-    String spoofFingerprintValue;
+    std::string spoofFingerprintValue;
 
     void readJson() {
         LOGD("JSON contains %d keys!", static_cast<int>(json.size()));
@@ -314,7 +314,7 @@ private:
         if (pkgName == VENDING_PACKAGE) {
             LOGD("JNI %s: Calling EntryPointVending.init", niceName);
             auto entryInit = env->GetStaticMethodID(entryClass, "init", "(II)V");
-            env->CallStaticVoidMethod(entryClass, entryInit, verboseLogs, spoofVendingFingerprint, spoofVendingSdk, spoofFingerprintValue);
+            env->CallStaticVoidMethod(entryClass, entryInit, verboseLogs, spoofVendingFingerprint, spoofVendingSdk, (const char *) spoofFingerprintValue);
         } else {
             LOGD("JNI %s: Sending JSON", niceName);
             auto receiveJson = env->GetStaticMethodID(entryClass, "receiveJson", "(Ljava/lang/String;)V");

--- a/app/src/main/java/es/chiteroman/playintegrityfix/EntryPointVending.java
+++ b/app/src/main/java/es/chiteroman/playintegrityfix/EntryPointVending.java
@@ -36,27 +36,28 @@ public final class EntryPointVending {
                 LOG("FINGERPRINT field not accessible: " + e);
             }
         }
-        int requestSdk = spoofVendingSdk == 1 ? 32 : spoofVendingSdk;
-        int targetSdk = Math.min(Build.VERSION.SDK_INT, requestSdk);
-        int oldValue;
-        try {
-            Field field = Build.VERSION.class.getDeclaredField("SDK_INT");
-            field.setAccessible(true);
-            oldValue = field.getInt(null);
-            if (oldValue == targetSdk) {
-                if (verboseLogs > 2) LOG(String.format("[SDK_INT]: %d (unchanged)", oldValue));
+        else {
+            int requestSdk = spoofVendingSdk == 1 ? 32 : spoofVendingSdk;
+            int targetSdk = Math.min(Build.VERSION.SDK_INT, requestSdk);
+            int oldValue;
+            try {
+                Field field = Build.VERSION.class.getDeclaredField("SDK_INT");
+                field.setAccessible(true);
+                oldValue = field.getInt(null);
+                if (oldValue == targetSdk) {
+                    if (verboseLogs > 2) LOG(String.format("[SDK_INT]: %d (unchanged)", oldValue));
+                    field.setAccessible(false);
+                    return;
+                }
+                field.set(null, targetSdk);
                 field.setAccessible(false);
-                return;
+                LOG(String.format("[SDK_INT]: %d -> %d", oldValue, targetSdk));
+            } catch (NoSuchFieldException e) {
+                LOG("SDK_INT field not found: " + e);
+            } catch (SecurityException | IllegalAccessException | IllegalArgumentException |
+                     NullPointerException | ExceptionInInitializerError e) {
+                LOG("SDK_INT field not accessible: " + e);
             }
-            field.set(null, targetSdk);
-            field.setAccessible(false);
-            LOG(String.format("[SDK_INT]: %d -> %d", oldValue, targetSdk));
-        } catch (NoSuchFieldException e) {
-             LOG("SDK_INT field not found: " + e);
-         } catch (SecurityException | IllegalAccessException | IllegalArgumentException |
-                 NullPointerException | ExceptionInInitializerError e) {
-             LOG("SDK_INT field not accessible: " + e);
-         }
+        }
     }
 }
-

--- a/app/src/main/java/es/chiteroman/playintegrityfix/EntryPointVending.java
+++ b/app/src/main/java/es/chiteroman/playintegrityfix/EntryPointVending.java
@@ -12,7 +12,7 @@ public final class EntryPointVending {
     }
 
     @SuppressLint("DefaultLocale")
-    public static void init(int verboseLogs, int spoofVendingFingerprint, int spoofVendingSdk, const char * spoofFingerprintValue) {
+    public static void init(int verboseLogs, int spoofVendingFingerprint, int spoofVendingSdk, char *spoofFingerprintValue) {
         if (spoofVendingSdk > 0){
             int requestSdk = spoofVendingSdk == 1 ? 32 : spoofVendingSdk;
             int targetSdk = Math.min(Build.VERSION.SDK_INT, requestSdk);
@@ -43,7 +43,7 @@ public final class EntryPointVending {
             Field field = Build.VERSION.class.getDeclaredField("FINGERPRINT");
             field.setAccessible(true);
             oldValue = String.valueOf(field.get(null));
-            if (oldValue.equals(spoofFingerprintValue) {
+            if (oldValue.equals(spoofFingerprintValue)) {
                 if (verboseLogs > 2) LOG(String.format("[FINGERPRINT]: %s (unchanged)", oldValue));
                 field.setAccessible(false);
                 return;
@@ -59,6 +59,7 @@ public final class EntryPointVending {
         }
     }
 }
+
 
 
 

--- a/app/src/main/java/es/chiteroman/playintegrityfix/EntryPointVending.java
+++ b/app/src/main/java/es/chiteroman/playintegrityfix/EntryPointVending.java
@@ -12,29 +12,51 @@ public final class EntryPointVending {
     }
 
     @SuppressLint("DefaultLocale")
-    public static void init(int verboseLogs, int spoofVendingSdk) {
-        if (spoofVendingSdk < 1) return;
-        int requestSdk = spoofVendingSdk == 1 ? 32 : spoofVendingSdk;
-        int targetSdk = Math.min(Build.VERSION.SDK_INT, requestSdk);
-        int oldValue;
+    public static void init(int verboseLogs, int spoofVendingFingerprint, int spoofVendingSdk, std::string spoofFingerprintValue) {
+        if (spoofVendingSdk > 0){
+            int requestSdk = spoofVendingSdk == 1 ? 32 : spoofVendingSdk;
+            int targetSdk = Math.min(Build.VERSION.SDK_INT, requestSdk);
+            int oldValue;
+            try {
+                Field field = Build.VERSION.class.getDeclaredField("SDK_INT");
+                field.setAccessible(true);
+                oldValue = field.getInt(null);
+                if (oldValue == targetSdk) {
+                    if (verboseLogs > 2) LOG(String.format("[SDK_INT]: %d (unchanged)", oldValue));
+                    field.setAccessible(false);
+                    return;
+                }
+                field.set(null, targetSdk);
+                field.setAccessible(false);
+                LOG(String.format("[SDK_INT]: %d -> %d", oldValue, targetSdk));
+            } catch (NoSuchFieldException e) {
+                LOG("SDK_INT field not found: " + e);
+            } catch (SecurityException | IllegalAccessException | IllegalArgumentException |
+                     NullPointerException | ExceptionInInitializerError e) {
+                LOG("SDK_INT field not accessible: " + e);
+            }
+            return
+        }
+        if (spoofVendingFingerprint < 1) return;
+        String oldValue;
         try {
-            Field field = Build.VERSION.class.getDeclaredField("SDK_INT");
+            Field field = Build.VERSION.class.getDeclaredField("FINGERPRINT");
             field.setAccessible(true);
-            oldValue = field.getInt(null);
-            if (oldValue == targetSdk) {
-                if (verboseLogs > 2) LOG(String.format("[SDK_INT]: %d (unchanged)", oldValue));
+            oldValue = String.valueOf(field.get(null));
+            if (oldValue.equals(spoofFingerprintValue) {
+                if (verboseLogs > 2) LOG(String.format("[FINGERPRINT]: %s (unchanged)", oldValue));
                 field.setAccessible(false);
                 return;
             }
-            field.set(null, targetSdk);
+            field.set(null, spoofFingerprintValue);
             field.setAccessible(false);
-            LOG(String.format("[SDK_INT]: %d -> %d", oldValue, targetSdk));
+            LOG(String.format("[FINGERPRINT]: %s -> %s", oldValue, spoofFingerprintValue));
         } catch (NoSuchFieldException e) {
-            LOG("SDK_INT field not found: " + e);
+            LOG("FINGERPRINT field not found: " + e);
         } catch (SecurityException | IllegalAccessException | IllegalArgumentException |
                  NullPointerException | ExceptionInInitializerError e) {
-            LOG("SDK_INT field not accessible: " + e);
-
+            LOG("FINGERPRINT field not accessible: " + e);
         }
     }
 }
+

--- a/app/src/main/java/es/chiteroman/playintegrityfix/EntryPointVending.java
+++ b/app/src/main/java/es/chiteroman/playintegrityfix/EntryPointVending.java
@@ -12,7 +12,7 @@ public final class EntryPointVending {
     }
 
     @SuppressLint("DefaultLocale")
-    public static void init(int verboseLogs, int spoofVendingFingerprint, int spoofVendingSdk, std::string spoofFingerprintValue) {
+    public static void init(int verboseLogs, int spoofVendingFingerprint, int spoofVendingSdk, String spoofFingerprintValue) {
         if (spoofVendingSdk > 0){
             int requestSdk = spoofVendingSdk == 1 ? 32 : spoofVendingSdk;
             int targetSdk = Math.min(Build.VERSION.SDK_INT, requestSdk);
@@ -59,4 +59,5 @@ public final class EntryPointVending {
         }
     }
 }
+
 

--- a/app/src/main/java/es/chiteroman/playintegrityfix/EntryPointVending.java
+++ b/app/src/main/java/es/chiteroman/playintegrityfix/EntryPointVending.java
@@ -12,7 +12,7 @@ public final class EntryPointVending {
     }
 
     @SuppressLint("DefaultLocale")
-    public static void init(int verboseLogs, int spoofVendingFingerprint, int spoofVendingSdk, String spoofFingerprintValue) {
+    public static void init(int verboseLogs, int spoofVendingFingerprint, int spoofVendingSdk, const char * spoofFingerprintValue) {
         if (spoofVendingSdk > 0){
             int requestSdk = spoofVendingSdk == 1 ? 32 : spoofVendingSdk;
             int targetSdk = Math.min(Build.VERSION.SDK_INT, requestSdk);
@@ -59,5 +59,6 @@ public final class EntryPointVending {
         }
     }
 }
+
 
 

--- a/app/src/main/java/es/chiteroman/playintegrityfix/EntryPointVending.java
+++ b/app/src/main/java/es/chiteroman/playintegrityfix/EntryPointVending.java
@@ -13,55 +13,48 @@ public final class EntryPointVending {
 
     @SuppressLint("DefaultLocale")
     public static void init(int verboseLogs, int spoofVendingFingerprint, int spoofVendingSdk, String spoofFingerprintValue) {
-        if (spoofVendingSdk > 0){
-            int requestSdk = spoofVendingSdk == 1 ? 32 : spoofVendingSdk;
-            int targetSdk = Math.min(Build.VERSION.SDK_INT, requestSdk);
-            int oldValue;
+        if (spoofVendingSdk < 1){
+            if (spoofVendingFingerprint < 1) return;
+            String oldValue;
             try {
-                Field field = Build.VERSION.class.getDeclaredField("SDK_INT");
+                Field field = Build.VERSION.class.getDeclaredField("FINGERPRINT");
                 field.setAccessible(true);
-                oldValue = field.getInt(null);
-                if (oldValue == targetSdk) {
-                    if (verboseLogs > 2) LOG(String.format("[SDK_INT]: %d (unchanged)", oldValue));
+                oldValue = String.valueOf(field.get(null));
+                if (oldValue.equals(spoofFingerprintValue)) {
+                    if (verboseLogs > 2) LOG(String.format("[FINGERPRINT]: %s (unchanged)", oldValue));
                     field.setAccessible(false);
                     return;
                 }
-                field.set(null, targetSdk);
+                field.set(null, spoofFingerprintValue);
                 field.setAccessible(false);
-                LOG(String.format("[SDK_INT]: %d -> %d", oldValue, targetSdk));
+                LOG(String.format("[FINGERPRINT]: %s -> %s", oldValue, spoofFingerprintValue));
             } catch (NoSuchFieldException e) {
-                LOG("SDK_INT field not found: " + e);
+                LOG("FINGERPRINT field not found: " + e);
             } catch (SecurityException | IllegalAccessException | IllegalArgumentException |
                      NullPointerException | ExceptionInInitializerError e) {
-                LOG("SDK_INT field not accessible: " + e);
+                LOG("FINGERPRINT field not accessible: " + e);
             }
-            return;
         }
-        if (spoofVendingFingerprint < 1) return;
-        String oldValue;
+        int requestSdk = spoofVendingSdk == 1 ? 32 : spoofVendingSdk;
+        int targetSdk = Math.min(Build.VERSION.SDK_INT, requestSdk);
+        int oldValue;
         try {
-            Field field = Build.VERSION.class.getDeclaredField("FINGERPRINT");
+            Field field = Build.VERSION.class.getDeclaredField("SDK_INT");
             field.setAccessible(true);
-            oldValue = String.valueOf(field.get(null));
-            if (oldValue.equals(spoofFingerprintValue)) {
-                if (verboseLogs > 2) LOG(String.format("[FINGERPRINT]: %s (unchanged)", oldValue));
+            oldValue = field.getInt(null);
+            if (oldValue == targetSdk) {
+                if (verboseLogs > 2) LOG(String.format("[SDK_INT]: %d (unchanged)", oldValue));
                 field.setAccessible(false);
                 return;
             }
-            field.set(null, spoofFingerprintValue);
+            field.set(null, targetSdk);
             field.setAccessible(false);
-            LOG(String.format("[FINGERPRINT]: %s -> %s", oldValue, spoofFingerprintValue));
+            LOG(String.format("[SDK_INT]: %d -> %d", oldValue, targetSdk));
         } catch (NoSuchFieldException e) {
-            LOG("FINGERPRINT field not found: " + e);
-        } catch (SecurityException | IllegalAccessException | IllegalArgumentException |
+             LOG("SDK_INT field not found: " + e);
+         } catch (SecurityException | IllegalAccessException | IllegalArgumentException |
                  NullPointerException | ExceptionInInitializerError e) {
-            LOG("FINGERPRINT field not accessible: " + e);
-        }
+             LOG("SDK_INT field not accessible: " + e);
+         }
     }
 }
-
-
-
-
-
-

--- a/app/src/main/java/es/chiteroman/playintegrityfix/EntryPointVending.java
+++ b/app/src/main/java/es/chiteroman/playintegrityfix/EntryPointVending.java
@@ -35,8 +35,7 @@ public final class EntryPointVending {
                      NullPointerException | ExceptionInInitializerError e) {
                 LOG("FINGERPRINT field not accessible: " + e);
             }
-        }
-        else {
+        } else {
             int requestSdk = spoofVendingSdk == 1 ? 32 : spoofVendingSdk;
             int targetSdk = Math.min(Build.VERSION.SDK_INT, requestSdk);
             int oldValue;

--- a/app/src/main/java/es/chiteroman/playintegrityfix/EntryPointVending.java
+++ b/app/src/main/java/es/chiteroman/playintegrityfix/EntryPointVending.java
@@ -12,7 +12,7 @@ public final class EntryPointVending {
     }
 
     @SuppressLint("DefaultLocale")
-    public static void init(int verboseLogs, int spoofVendingFingerprint, int spoofVendingSdk, char *spoofFingerprintValue) {
+    public static void init(int verboseLogs, int spoofVendingFingerprint, int spoofVendingSdk, String spoofFingerprintValue) {
         if (spoofVendingSdk > 0){
             int requestSdk = spoofVendingSdk == 1 ? 32 : spoofVendingSdk;
             int targetSdk = Math.min(Build.VERSION.SDK_INT, requestSdk);
@@ -59,6 +59,7 @@ public final class EntryPointVending {
         }
     }
 }
+
 
 
 

--- a/app/src/main/java/es/chiteroman/playintegrityfix/EntryPointVending.java
+++ b/app/src/main/java/es/chiteroman/playintegrityfix/EntryPointVending.java
@@ -35,7 +35,7 @@ public final class EntryPointVending {
                      NullPointerException | ExceptionInInitializerError e) {
                 LOG("SDK_INT field not accessible: " + e);
             }
-            return
+            return;
         }
         if (spoofVendingFingerprint < 1) return;
         String oldValue;
@@ -59,6 +59,7 @@ public final class EntryPointVending {
         }
     }
 }
+
 
 
 

--- a/app/src/main/java/es/chiteroman/playintegrityfix/EntryPointVending.java
+++ b/app/src/main/java/es/chiteroman/playintegrityfix/EntryPointVending.java
@@ -14,10 +14,11 @@ public final class EntryPointVending {
     @SuppressLint("DefaultLocale")
     public static void init(int verboseLogs, int spoofVendingFingerprint, int spoofVendingSdk, String spoofFingerprintValue) {
         if (spoofVendingSdk < 1){
+            // Only spoof FINGERPRINT to Play Store if not forcing legacy verdict           
             if (spoofVendingFingerprint < 1) return;
             String oldValue;
             try {
-                Field field = Build.VERSION.class.getDeclaredField("FINGERPRINT");
+                Field field = Build.class.getDeclaredField("FINGERPRINT");
                 field.setAccessible(true);
                 oldValue = String.valueOf(field.get(null));
                 if (oldValue.equals(spoofFingerprintValue)) {
@@ -58,3 +59,4 @@ public final class EntryPointVending {
          }
     }
 }
+

--- a/module/autopif2.sh
+++ b/module/autopif2.sh
@@ -162,7 +162,7 @@ if [ -f "$MIGRATE" ]; then
   if [ -n "$ARGS" ]; then
     grep_json() { [ -f "$2" ] && grep -m1 "$1" $2 | cut -d\" -f4; }
     verboseLogs=$(grep_json "VERBOSE_LOGS" $OLDJSON);
-    ADVSETTINGS="spoofBuild spoofProps spoofProvider spoofSignature spoofVendingSdk verboseLogs";
+    ADVSETTINGS="spoofBuild spoofProps spoofProvider spoofSignature spoofVendingFingerprint spoofVendingSdk verboseLogs";
     for SETTING in $ADVSETTINGS; do
       eval [ -z \"\$$SETTING\" ] \&\& $SETTING=$(grep_json "$SETTING" $OLDJSON);
       eval TMPVAL=\$$SETTING;

--- a/module/example.pif.json
+++ b/module/example.pif.json
@@ -31,6 +31,7 @@
     "spoofProps": "1",
     "spoofProvider": "1",
     "spoofSignature": "0",
+    "spoofVendingFingerprint": "0",
     "spoofVendingSdk": "0",
     "verboseLogs": "0"
 }

--- a/module/migrate.sh
+++ b/module/migrate.sh
@@ -114,12 +114,13 @@ if [ -z "$DEVICE_INITIAL_SDK_INT" -o "$DEVICE_INITIAL_SDK_INT" = "null" ]; then
   DEVICE_INITIAL_SDK_INT=25;
 fi;
 
-ADVSETTINGS="spoofBuild spoofProps spoofProvider spoofSignature spoofVendingSdk verboseLogs";
+ADVSETTINGS="spoofBuild spoofProps spoofProvider spoofSignature spoofVendingFingerprint spoofVendingSdk verboseLogs";
 
 spoofBuild=1;
 spoofProps=1;
 spoofProvider=1;
 spoofSignature=0;
+spoofVendingFingerprint=0;
 spoofVendingSdk=0;
 verboseLogs=0;
 


### PR DESCRIPTION
spoofVendingFingerprint = 0 / 1
When 0, no impact on Vending
When 1, same FINGERPRINT from custom.pif.json is injected into Vending
Unless spoofVendingSdk is enabled also, in which case FINGERPRINT is not injected.

Would not be difficult to modify spoofVendingFingerprint to accept a custom string different from the FINGERPRINT in the file.

Edit: No idea how to squash these numerous changes/corrections, etc into one. I have tested this works and checked logs but took multiple edits... was hoping to simply put through a single commit. If you could just look at the overall changes in the files changed rather than going through 27 commits!

https://github.com/gavdoc38/PlayIntegrityFork/actions/runs/17311530143
Technically that is what I tested, which is everything right before the detection fixes merge.