### PR TITLE
Add curl as a downloader fallback

### DIFF
--- a/module/autopif2.sh
+++ b/module/autopif2.sh
@@ -45,8 +45,24 @@ find_busybox() {
   return 1;
 }
 
+# --- NEW, PORTABLE FIX ---
 if which wget2 >/dev/null; then
   wget() { wget2 "$@"; }
+elif which curl >/dev/null; then
+  # Found curl in PATH. Define a function to translate.
+  # The script calls: wget -q -O <file> --no-check-certificate <url>
+  # Let's map arguments.
+  wget() {
+    # This is a simple translation for the script's specific use case.
+    # $1= -q (ignored, curl is quiet with -s)
+    # $2= -O
+    # $3= <file> (output)
+    # $4= --no-check-certificate (ignored, curl uses -k)
+    # $5= <url> (the URL)
+    
+    # Use 'command' to avoid recursion if curl is an alias
+    command curl -L -s -k -o "$3" "$5"
+  }
 elif ! which wget >/dev/null || grep -q "wget-curl" $(which wget); then
   if ! find_busybox; then
     die "wget not found";

--- a/module/autopif2.sh
+++ b/module/autopif2.sh
@@ -45,24 +45,12 @@ find_busybox() {
   return 1;
 }
 
-# --- NEW, PORTABLE FIX ---
 if which wget2 >/dev/null; then
   wget() { wget2 "$@"; }
 elif which curl >/dev/null; then
-  # Found curl in PATH. Define a function to translate.
-  # The script calls: wget -q -O <file> --no-check-certificate <url>
-  # Let's map arguments.
-  wget() {
-    # This is a simple translation for the script's specific use case.
-    # $1= -q (ignored, curl is quiet with -s)
-    # $2= -O
-    # $3= <file> (output)
-    # $4= --no-check-certificate (ignored, curl uses -k)
-    # $5= <url> (the URL)
-    
-    # Use 'command' to avoid recursion if curl is an alias
-    command curl -L -s -k -o "$3" "$5"
-  }
+  # map arguments for simple equivalent use with:
+  # wget -q -O <file> --no-check-certificate <url>
+  wget() { curl -S -s -k -o "$3" "$5"; }
 elif ! which wget >/dev/null || grep -q "wget-curl" $(which wget); then
   if ! find_busybox; then
     die "wget not found";


### PR DESCRIPTION
Hi osm0sis,

On some devices (like my LineageOS build), the built-in BusyBox wget fails to download the metadata, even with root, leading to the "Failed to extract information" error.

This PR adds a check for curl to the downloader selection logic.

If curl is present in the system $PATH (as it is on my ROM), the script will now use it as a preferred downloader, translating the wget arguments to curl arguments. This is more robust than the BusyBox wget fallback and avoids the failure, while still being fully portable and not assuming curl exists.

This successfully fixed the issue on my armeabi-v7a device. Thanks for your work on this module!