### PR TITLE
fix action.sh failing on non-ash shells

### DIFF
--- a/module/action.sh
+++ b/module/action.sh
@@ -1,8 +1,10 @@
 MODPATH="${0%/*}"
 
 # ensure not running in busybox ash standalone shell
-set +o standalone
-unset ASH_STANDALONE
+if [ -n "$ASH_STANDALONE" ]; then
+    set +o standalone
+    unset ASH_STANDALONE
+fi
 
 sh $MODPATH/autopif4.sh -m || exit 1
 


### PR DESCRIPTION
Running on LineageOS 23.2 with Magisk Alpha 30700, action.sh fails with:

    `./action.sh[4]: set: standalone: unknown option`

This happens because the script is executed by bash rather than busybox ash. The `set +o standalone` option is ash-specific

Fix by checking `ASH_STANDALONE` first, only set by busybox ash in standalone mode so the command is skipped on other shells 🤠

<img width="720" height="1520" alt="Screenshot_20260624-000902_SU" src="https://github.com/user-attachments/assets/8674b999-8ae3-40ee-95fd-5d90460f6793" />